### PR TITLE
Link Thesis Project dashboard

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -10,6 +10,7 @@ This folder is the central place for thesis execution planning and progress trac
 ## GitHub Issues tracking (execution)
 We track day-to-day execution in GitHub Issues so progress is visible and auditable.
 
+- Project dashboard: https://github.com/users/notoctavio/projects/2
 - Milestone: `Thesis - End of May`
 - Labels:
   - `thesis`


### PR DESCRIPTION
Adds the GitHub Projects dashboard link (Project #2) to docs/plan/README.md.