### PR TITLE
Clarify thesis workflow + doc auto-update rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@
 - [ ] Updated `docs/ai/PREFERENCES.md` if a new recurring preference was identified
 - [ ] Updated `docs/ai/LESSONS_LEARNED.md` if a new recurring mistake pattern was identified
 - [ ] Updated relevant `docs/plan/*` files for planning/progress
+- [ ] Linked the relevant GitHub Issue(s) and ensured the Project board is consistent
 
 ## Notes
 - 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,11 @@
 Thanks for contributing to this thesis repository.
 
 ## Workflow
+- Track work as GitHub Issues (milestone `Thesis - End of May`) and use the dashboard: https://github.com/users/notoctavio/projects/2
 - Create or use a feature branch (do not push directly to `main`).
 - Open a pull request with a clear summary and validation notes.
-- Ensure GitHub checks pass before merge.
+- Ensure required GitHub checks pass before merge.
+- Log weekly progress in `docs/plan/` and record major decisions in `docs/plan/decision-log.md`.
 
 ## Required checks before PR
 - Run local integrity checks:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ To keep instructions consistent across assistants:
   - `docs/ai/LESSONS_LEARNED.md`
 - When workflow, structure, or data inventory changes, update `docs/ai/RULES.md` first, then related adapter/README files if needed.
 
+## Workflow (recommended)
+This repo follows an **Issues-first** workflow for thesis execution.
+
+- Track tasks in GitHub Issues (milestone `Thesis - End of May`)
+- Use the Project dashboard for a board/table view: https://github.com/users/notoctavio/projects/2
+- Work on a branch → open a PR → ensure required checks pass → merge
+- Log weekly progress + decisions in `docs/plan/`
+
 ## Lightweight Automation
 - Local integrity command: `python3 scripts/validate_repo_integrity.py`
 - CI uses `VALIDATE_DATASETS=0` so cloud checks validate repo wiring/docs without requiring local datasets.

--- a/docs/ai/RULES.md
+++ b/docs/ai/RULES.md
@@ -27,14 +27,36 @@ Root adapter files (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`, `CODEX.md`) should st
 3. Keep work reproducible and thesis-grade (clear logic, traceable steps, explicit assumptions).
 4. Prefer Python 3.x with `pandas`, `numpy`, `scipy`; use `pytorch` for deep learning unless changed explicitly.
 
-## Documentation Maintenance Rule
-When repository structure, workflow, or data inventory changes, update:
-- `docs/ai/RULES.md` first
-- Root adapters (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`, `CODEX.md`) only if needed
-- Relevant folder `README.md` files (`data/README.md`, `data_test/README.md`)
-- `docs/ai/PREFERENCES.md` if a stable collaboration preference is discovered
-- `docs/ai/LESSONS_LEARNED.md` if a recurring mistake/pitfall is identified
-- Relevant planning docs in `docs/plan/`
+## Workflow (must follow)
+1. Pick or create the next task as a GitHub Issue (label it `thesis` + `phase:*`, assign the milestone).
+2. Move it on the Project board: https://github.com/users/notoctavio/projects/2
+3. Work on a branch.
+4. Open a PR; ensure required checks pass.
+5. Merge the PR.
+6. Reflect progress:
+   - Weekly log: `docs/plan/*`
+   - Decision log when needed: `docs/plan/decision-log.md`
+
+## Documentation Maintenance Rule (agents must do this)
+When you change repository structure, workflow, automation, or data inventory, you must proactively update the docs **in the same PR**.
+
+Update order:
+- `docs/ai/RULES.md` first (canonical)
+- Root adapters (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`, `CODEX.md`) only if the pointer/compatibility needs changes
+- User-facing docs:
+  - `README.md` (high-level workflow/navigation)
+  - Relevant folder READMEs (`data/README.md`, `data_test/README.md`) when their contents/meaning changes
+- Process logs:
+  - `docs/plan/*` (weekly logs / roadmap updates / decision log)
+- Collaboration memory:
+  - `docs/ai/PREFERENCES.md` for stable preferences
+  - `docs/ai/LESSONS_LEARNED.md` for recurring pitfalls
+
+## Minimal doc update checklist (for every PR)
+- If behavior/workflow changed: update `docs/ai/RULES.md` + `README.md`
+- If you learned a repeatable preference: update `docs/ai/PREFERENCES.md`
+- If you hit a recurring mistake: update `docs/ai/LESSONS_LEARNED.md`
+- If work completed a milestone chunk: update `docs/plan/*` (weekly log/roadmap)
 
 ## Automation Baseline
 - Integrity script: `scripts/validate_repo_integrity.py`

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -31,5 +31,11 @@ If you only want to preview what would be created:
 python3 scripts/plan_csv_to_github_issues.py --dry-run
 ```
 
+## Weekly logs
+Create a weekly log file when you do meaningful work. Suggested naming:
+- `docs/plan/weekly-YYYY-Www.md` (example: `docs/plan/weekly-2026-W11.md`)
+
+Use `weekly-log-template.md` as the template and link the relevant GitHub issues/PRs.
+
 ## Usage rule
 When a new sprint/phase starts, update `thesis-roadmap.md` first, then log execution details in weekly logs and close the relevant GitHub issues.


### PR DESCRIPTION
Updates workflow documentation across README, docs/ai/RULES.md, docs/plan/README.md, CONTRIBUTING.md, and PR template.\n\nKey changes:\n- Explicit Issues-first workflow + Project dashboard link\n- Weekly log naming guidance\n- Stronger rule: agents must update docs in the same PR when workflow/structure changes\n\nValidation:\n- python3 scripts/validate_repo_integrity.py\n- VALIDATE_DATASETS=0 python3 scripts/validate_repo_integrity.py